### PR TITLE
subPath pointing to values

### DIFF
--- a/charts/hertzbeat/templates/database/statefulset.yaml
+++ b/charts/hertzbeat/templates/database/statefulset.yaml
@@ -63,7 +63,7 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /var/lib/postgresql/data
-          subPath: ""
+          subPath: {{ .Values.database.persistence.subPath }}
         - mountPath: /docker-entrypoint-initdb.d/schema.sql
           subPath: schema.sql
           name: schema


### PR DESCRIPTION
## What's changed?

templates/databases/statefulset.yaml line#66 now points to the value {{ .Values.database.persistence.subPath }}


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.
