### PR TITLE
fix: add missing compression config for VictoriaMetrics to resolve NPE

### DIFF
--- a/charts/hertzbeat/templates/manager/configmap.yaml
+++ b/charts/hertzbeat/templates/manager/configmap.yaml
@@ -149,6 +149,8 @@ data:
           insert:
             buffer-size: 100
             flush-interval: 3
+            compression:
+              enabled: false
         td-engine:
           enabled: false
           driver-class-name: com.taosdata.jdbc.rs.RestfulDriver


### PR DESCRIPTION
**Problem Description**
When deploying HertzBeat using the Helm Chart with VictoriaMetrics enabled as the default time-series data store, the Manager component continuously throws NullPointerException in logs, causing metric data to fail to write to VictoriaMetrics. Queries for historical monitoring data return empty values.

**Reproduction Steps**
- Deploy HertzBeat using the current Helm Chart (with victoria-metrics storage enabled by default)
- Check Manager Pod logs, and the following error appears:
java.lang.NullPointerException: Cannot invoke "org.apache.hertzbeat.warehouse.store.history.tsdb.vm.VictoriaMetricsProperties$Compression.enabled()" 
because the return value of "org.apache.hertzbeat.warehouse.store.history.tsdb.vm.VictoriaMetricsProperties$InsertConfig.compression()" is null
- Query historical metric data via API, returns values: {}


**Root Cause Analysis**
The warehouse.store.victoria-metrics.insert configuration node in the Manager ConfigMap template of the Helm Chart lacks the compression sub-configuration item. This causes the HertzBeat code to return null when calling insertConfig.getCompression().enabled(), which triggers the null pointer exception.

**Fix Solution**
Modify charts/hertzbeat/templates/manager/configmap.yaml to add the missing compression configuration under the victoria-metrics.insert node:

```
insert:
  buffer-size: 100
  flush-interval: 3
  # Newly added configuration
  compression:
    enabled: false
```
**Verification Results**
After redeploying the Helm Chart, the NPE error no longer appears in Manager logs
Metric data is written to VictoriaMetrics normally
Historical metric data queries via API return valid values correctly

