### PR TITLE
[fix] add startup probes so manager survives slow boot

### DIFF
--- a/charts/hertzbeat/Chart.yaml
+++ b/charts/hertzbeat/Chart.yaml
@@ -29,7 +29,7 @@ icon: https://raw.githubusercontent.com/apache/hertzbeat/master/home/static/img/
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.0
+version: 1.8.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/hertzbeat/templates/collector/deployment.yaml
+++ b/charts/hertzbeat/templates/collector/deployment.yaml
@@ -51,6 +51,11 @@ spec:
           ports:
             - containerPort: 1159
               protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: 1159
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             tcpSocket:
               port: 1159

--- a/charts/hertzbeat/templates/manager/deployment.yaml
+++ b/charts/hertzbeat/templates/manager/deployment.yaml
@@ -53,6 +53,11 @@ spec:
             - name: cluster
               containerPort: 1158
               protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: 1157
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             tcpSocket:
               port: 1157


### PR DESCRIPTION
## What's changed?

Fixes apache/hertzbeat#3849: `helm install` leaves the manager pod in permanent CrashLoopBackOff on many clusters.

Two compounding causes, reproduced on a kind cluster with chart 1.7.3:

1. The manager starts before postgres is ready, fails with `Connection to hertzbeat-database:5432 refused` and exits. This part self-heals via restarts once the database is up.
2. The bare `livenessProbe` (tcpSocket 1157, no `initialDelaySeconds`, no `startupProbe`) kills the container ~30s after start with k8s defaults, while the manager needs well over 30s to boot on typical nodes. Every retry gets killed mid-boot, so the pod never recovers — `kubectl describe` shows `Liveness probe failed: dial tcp ...:1157: connect: connection refused`.

The crash is invisible in `kubectl logs` because logback routes everything to file appenders inside the container, which is why the issue reports "no useful log".

Fix: add a `startupProbe` (10s × 30 = 5 min boot budget) to the manager and collector deployments; liveness only takes over after startup succeeds. Verified on kind: before — manager restarts forever; after — one restart while postgres boots, then all pods reach `1/1 Running`.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.
