### PR TITLE
[fix] make CI runnable again (ASF actions allowlist + stale setup)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,25 +25,32 @@ on:
 
 jobs:
   lint-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
-          
+          python-version: 3.11
+
+      # helm is preinstalled on the hosted runner; chart-testing is installed from
+      # its release tarball because the ASF actions allowlist rejects third-party
+      # actions like helm/chart-testing-action and azure/setup-helm
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1      
-      
+        run: |
+          CT_VERSION=3.11.0
+          curl -sSLo /tmp/ct.tgz "https://github.com/helm/chart-testing/releases/download/v${CT_VERSION}/chart-testing_${CT_VERSION}_linux_amd64.tar.gz"
+          mkdir -p /tmp/ct
+          tar -xzf /tmp/ct.tgz -C /tmp/ct
+          sudo mv /tmp/ct/ct /usr/local/bin/ct
+          sudo mkdir -p /etc/ct
+          sudo cp /tmp/ct/etc/chart_schema.yaml /tmp/ct/etc/lintconf.yaml /etc/ct/
+          pip install yamllint yamale
+
+
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
 
@@ -52,7 +59,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install k8s

--- a/ct.yaml
+++ b/ct.yaml
@@ -25,3 +25,4 @@ pages-index-path: docs/index.yaml
 package-path: docs
 index-path: docs/index.yaml
 pr:
+validate-maintainers: false


### PR DESCRIPTION
## What's changed?

Every workflow run in this repo since late 2025 — including pushes to `main` — fails with `startup_failure` and zero jobs. The run banner shows the actual cause: the **ASF org actions policy** only allows actions owned by GitHub/apache or matching an explicit allowlist, and `azure/setup-helm` / `helm/chart-testing-action` match neither, so the workflow is refused before any job starts.

- drop `azure/setup-helm` (helm is preinstalled on hosted runners) and `helm/chart-testing-action` (install `ct` from its release tarball + pip deps instead)
- `runs-on: ubuntu-22.04` → `ubuntu-latest` (22.04 hosted runners are retired)
- bump `actions/checkout` v3 → v4, `actions/setup-python` v4 → v5; migrate removed `::set-output` to `$GITHUB_OUTPUT`
- `validate-maintainers: false` in ct.yaml — the "hertzbeat" maintainer entry is a mailing-list identity, not a GitHub user, so ct lint fails on it

Every step was replayed locally before pushing:

- helm availability: Helm 3.21.3 is preinstalled per the official [runner-images manifest](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md)
- the new chart-testing install script: executed verbatim in a clean `ubuntu:24.04` container — `ct` v3.11.0 installs and runs
- `ct lint`: passes with the locally-installed ct against this config, for both this branch and #23's chart change
- `ct install`: run against a real cluster (kind) with #23's chart — all components reach ready, release uninstalls cleanly, `All charts installed successfully`
- allowlist acceptance: pushing an intermediate commit that still contained `azure/setup-helm` reproduced `startup_failure`; removing the third-party actions flipped the run to `action_required` (awaiting approval)

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.
